### PR TITLE
Moved header settings so they're set before they're needed

### DIFF
--- a/ha-local-echo.py
+++ b/ha-local-echo.py
@@ -33,12 +33,12 @@ class HomeAssistant:
 
     def __init__(self, base_url=HA_BASE_URL):
         self.base_url = base_url
-        self.fetch_entities()
-
         self.headers = { 'content-type': 'application/json' }
 
         if HA_API_KEY is not None:
             self.headers['x-ha-access'] = HA_API_KEY
+
+        self.fetch_entities()
 
     def fetch_entities(self):
         print("Fetching Home Assistant entities...")
@@ -165,7 +165,7 @@ USN: uuid:Socket-1_0-221438K0100073::urn:schemas-upnp-org:device:basic:1
                 if stop_thread == True:
                     print("UPNP Reponder Thread closing socket and shutting down...")
                     ssdpmc_socket.close()
-                    return  
+                    return
                 print ("UPNP Responder socket.error exception occured: {0}".format(e.__str__))
 
             # SSDP M-SEARCH method received - respond to it unicast with our info
@@ -333,4 +333,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
I have an API key on my Home Assistant instance. Found that this script would not work because the headers were blank at the time HomeAssistant.fetch_entities() was being called in HomeAssistant.**init**. The headers were being set after fetch_entities() was called, when they should be set before.

Reordered the **init**() method so headers were set before the fetch_entities() call. Works as expected now.
